### PR TITLE
Add script to push Docker images to ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,17 +615,24 @@ Terraform state is stored in S3 with DynamoDB locking:
 - Staging: `s3://your-bucket/stg/terraform.tfstate`
 - Production: `s3://your-bucket/prod/terraform.tfstate`
 
-## Manual Deployment Steps
+## 手動デプロイ手順
 
-For manual deployments (not recommended for production):
+本番環境では推奨されませんが、手動でデプロイする場合の手順です：
 
-1. **Setup state backend** (run bootstrap first)
-2. **Build and push your Docker image to ECR**
-3. **Configure variables in terraform.tfvars**
-4. **Initialize Terraform**: `terraform init`
-5. **Plan deployment**: `terraform plan`
-6. **Apply configuration**: `terraform apply`
-7. **Update DNS** to point to the ALB DNS name
+1. **状態バックエンドのセットアップ**（事前にbootstrapを実行）
+2. **DockerイメージをECRにビルド & プッシュ**
+
+   ```bash
+   bash script/docker-push.sh -r <リージョン> -n <リポジトリ名> [-t <タグ>] [-f <Dockerfile>] [-c <コンテキスト>]
+   ```
+
+   このヘルパースクリプトはDockerイメージをビルドし、指定したECRリポジトリにプッシュします。
+   利用可能なオプションは`-h`で確認できます。
+3. **terraform.tfvarsの変数を設定**
+4. **Terraformの初期化**: `terraform init`
+5. **Planの実行**: `terraform plan`
+6. **設定の適用**: `terraform apply`
+7. **DNSを更新**してALBのDNS名を指すようにする
 
 ## GitHub Actions Features
 

--- a/script/docker-push.sh
+++ b/script/docker-push.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+使い方: $0 -r <リージョン> -n <リポジトリ名> [-t <タグ>] [-f <Dockerfile>] [-c <コンテキスト>]
+
+オプション:
+  -r, --region       ECRリポジトリのAWSリージョン
+  -n, --repository   ECRリポジトリ名
+  -t, --tag          使用するイメージタグ (デフォルト: latest)
+  -f, --dockerfile   使用するDockerfile (デフォルト: Dockerfile)
+  -c, --context      ビルドコンテキストディレクトリ (デフォルト: カレントディレクトリ)
+  -h, --help         このヘルプを表示
+USAGE
+}
+
+TAG=latest
+DOCKERFILE=Dockerfile
+CONTEXT=.
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -r|--region)
+      REGION="$2"
+      shift 2
+      ;;
+    -n|--repository)
+      REPOSITORY="$2"
+      shift 2
+      ;;
+    -t|--tag)
+      TAG="$2"
+      shift 2
+      ;;
+    -f|--dockerfile)
+      DOCKERFILE="$2"
+      shift 2
+      ;;
+    -c|--context)
+      CONTEXT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "不明な引数: $1"
+      usage
+      exit 1
+      ;;
+  esac
+
+done
+
+if [[ -z "${REGION:-}" || -z "${REPOSITORY:-}" ]]; then
+  echo "リージョンとリポジトリ名は必須です"
+  usage
+  exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPOSITORY}"
+
+aws ecr describe-repositories --repository-names "$REPOSITORY" --region "$REGION" >/dev/null 2>&1 || \
+  aws ecr create-repository --repository-name "$REPOSITORY" --region "$REGION" >/dev/null
+
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+
+docker build -t "${ECR_URI}:${TAG}" -f "$DOCKERFILE" "$CONTEXT"
+docker push "${ECR_URI}:${TAG}"
+
+echo "${ECR_URI}:${TAG} をプッシュしました"
+


### PR DESCRIPTION
## Summary
- add shell script for building and pushing images to a specified ECR repository
- document how to run the helper script in README
- translate manual deployment steps and helper script messaging into Japanese

## Testing
- `bash script/docker-push.sh -h`
- `shellcheck script/docker-push.sh` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y shellcheck` *(fails: Unable to locate package shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_688f08004634832a9e6a05eb0b8bb1cd