### PR TITLE
feat: add s3 access logging

### DIFF
--- a/terraform/modules/codepipeline/outputs.tf
+++ b/terraform/modules/codepipeline/outputs.tf
@@ -28,6 +28,16 @@ output "artifacts_bucket_arn" {
   value       = aws_s3_bucket.codepipeline_artifacts.arn
 }
 
+output "access_logs_bucket_name" {
+  description = "S3 access logs bucket name"
+  value       = aws_s3_bucket.access_logs.bucket
+}
+
+output "access_logs_bucket_arn" {
+  description = "S3 access logs bucket ARN"
+  value       = aws_s3_bucket.access_logs.arn
+}
+
 output "codepipeline_role_arn" {
   description = "CodePipeline IAM role ARN"
   value       = aws_iam_role.codepipeline_role.arn

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -18,6 +18,16 @@ output "logs_bucket_arn" {
   value       = aws_s3_bucket.app_logs.arn
 }
 
+output "access_logs_bucket_id" {
+  description = "S3 access logs bucket ID"
+  value       = aws_s3_bucket.access_logs.id
+}
+
+output "access_logs_bucket_arn" {
+  description = "S3 access logs bucket ARN"
+  value       = aws_s3_bucket.access_logs.arn
+}
+
 output "s3_access_role_arn" {
   description = "S3 access role ARN"
   value       = aws_iam_role.s3_access_role.arn


### PR DESCRIPTION
## Summary
- add dedicated S3 logging buckets for application and pipeline resources
- route S3 access logs from app and pipeline buckets to the logging buckets
- expose logging bucket identifiers as module outputs

## Testing
- `terraform fmt terraform/modules/s3 terraform/modules/codepipeline` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689299e6ed24832a817ac86dd411c3ba