### PR TITLE
feat: restrict security group egress

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -51,6 +51,9 @@ module "security_groups" {
   vpc_id      = module.vpc.vpc_id
   app_port    = 8080
   db_port     = 3306
+  alb_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  ecs_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  rds_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
 }
 
 module "alb" {

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -51,6 +51,9 @@ module "security_groups" {
   vpc_id      = module.vpc.vpc_id
   app_port    = 8080
   db_port     = 3306
+  alb_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  ecs_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  rds_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
 }
 
 module "alb" {

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -51,6 +51,9 @@ module "security_groups" {
   vpc_id      = module.vpc.vpc_id
   app_port    = 8080
   db_port     = 3306
+  alb_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  ecs_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  rds_egress_cidr_blocks = [module.vpc.vpc_cidr_block]
 }
 
 module "alb" {

--- a/terraform/modules/security_groups/main.tf
+++ b/terraform/modules/security_groups/main.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "alb" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.alb_egress_cidr_blocks
   }
 
   tags = {
@@ -59,7 +59,7 @@ resource "aws_security_group" "ecs" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.ecs_egress_cidr_blocks
   }
 
   tags = {
@@ -88,7 +88,7 @@ resource "aws_security_group" "rds" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.rds_egress_cidr_blocks
   }
 
   tags = {

--- a/terraform/modules/security_groups/variables.tf
+++ b/terraform/modules/security_groups/variables.tf
@@ -19,3 +19,18 @@ variable "db_port" {
   type        = number
   default     = 3306
 }
+
+variable "alb_egress_cidr_blocks" {
+  description = "CIDR blocks for ALB security group egress"
+  type        = list(string)
+}
+
+variable "ecs_egress_cidr_blocks" {
+  description = "CIDR blocks for ECS security group egress"
+  type        = list(string)
+}
+
+variable "rds_egress_cidr_blocks" {
+  description = "CIDR blocks for RDS security group egress"
+  type        = list(string)
+}


### PR DESCRIPTION
## Summary
- make security group egress destinations configurable
- require environments to pass explicit CIDR blocks

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689299e7c048832a9f0b85cb5fc351a6