### PR TITLE
feat: add rds multi-az option

### DIFF
--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -14,6 +14,7 @@ app_image = "your-account.dkr.ecr.ap-northeast-1.amazonaws.com/my-app:latest"
 db_name     = "appdb"
 db_username = "admin"
 db_password = "change-me-please"
+multi_az   = false
 
 # AWS Account Configuration
 aws_account_id = "123456789012"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -40,6 +40,12 @@ variable "db_password" {
   sensitive   = true
 }
 
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment"
+  type        = bool
+  default     = false
+}
+
 variable "aws_account_id" {
   description = "AWS account ID"
   type        = string

--- a/terraform/environments/prod/terraform.tfvars.example
+++ b/terraform/environments/prod/terraform.tfvars.example
@@ -14,6 +14,7 @@ certificate_arn = "arn:aws:acm:ap-northeast-1:123456789012:certificate/12345678-
 db_name     = "appdb"
 db_username = "admin"
 db_password = "super-secure-password-change-me"
+multi_az   = true
 
 # AWS Account Configuration
 aws_account_id = "123456789012"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -38,6 +38,12 @@ variable "db_password" {
   sensitive   = true
 }
 
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment"
+  type        = bool
+  default     = false
+}
+
 variable "ip_whitelist_enabled" {
   description = "Enable IP whitelist for WAF"
   type        = bool

--- a/terraform/environments/stg/terraform.tfvars.example
+++ b/terraform/environments/stg/terraform.tfvars.example
@@ -14,6 +14,7 @@ app_image = "your-account.dkr.ecr.ap-northeast-1.amazonaws.com/my-app:staging"
 db_name     = "appdb"
 db_username = "admin"
 db_password = "staging-password-change-me"
+multi_az   = false
 
 # AWS Account Configuration
 aws_account_id = "123456789012"

--- a/terraform/environments/stg/variables.tf
+++ b/terraform/environments/stg/variables.tf
@@ -39,6 +39,12 @@ variable "db_password" {
   sensitive   = true
 }
 
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment"
+  type        = bool
+  default     = false
+}
+
 variable "ip_whitelist_enabled" {
   description = "Enable IP whitelist for WAF"
   type        = bool

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -33,6 +33,7 @@ resource "aws_db_instance" "main" {
   max_allocated_storage = var.max_allocated_storage
   storage_type          = var.storage_type
   storage_encrypted     = var.storage_encrypted
+  multi_az              = var.multi_az
 
   engine         = var.engine
   engine_version = var.engine_version

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -101,6 +101,12 @@ variable "deletion_protection" {
   default     = true
 }
 
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment"
+  type        = bool
+  default     = false
+}
+
 variable "performance_insights_enabled" {
   description = "Enable Performance Insights"
   type        = bool


### PR DESCRIPTION
## Summary
- allow configuring RDS Multi-AZ
- document `multi_az` variable in envs and example tfvars

## Testing
- `terraform fmt terraform/modules/rds/variables.tf terraform/modules/rds/main.tf terraform/environments/dev/variables.tf terraform/environments/stg/variables.tf terraform/environments/prod/variables.tf terraform/environments/dev/terraform.tfvars.example terraform/environments/stg/terraform.tfvars.example terraform/environments/prod/terraform.tfvars.example` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce3820f4832a80327a24146444a5