### PR TITLE
ci: add terraform lint workflow

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -1,0 +1,27 @@
+name: Terraform Lint
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+      - 'modules/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Validate
+        run: |
+          set -e
+          for dir in terraform/environments/*; do
+            (cd "$dir" && terraform init -backend=false && terraform validate)
+          done


### PR DESCRIPTION
## Summary
- run terraform linting on pull requests touching terraform or module code

## Testing
- `terraform fmt -check -recursive` *(fails: command not found: terraform)*
- `for dir in terraform/environments/*; do (cd "$dir" && terraform init -backend=false && terraform validate); done` *(fails: command not found: terraform)*
- `curl -L -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/1.5.0/terraform_1.5.0_linux_amd64.zip` *(fails: CONNECT tunnel failed, response 403)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce81c3f0832a8de88638f29f7e91