### PR TITLE
chore: narrow artifacts to imagedefinitions

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,7 +30,6 @@ phases:
 artifacts:
   files:
     - imagedefinitions.json
-    - '**/*'
 
 cache:
   paths:


### PR DESCRIPTION
## Summary
- limit CodeBuild artifacts to only `imagedefinitions.json`
- confirm downstream CodePipeline deploy stage continues to read `imagedefinitions.json`

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce38a0c0832a863b215fcf181703