### PR TITLE
Install curl for Docker health check

### DIFF
--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -25,6 +25,7 @@ USER nextjs
 EXPOSE 8080
 
 # Health check
+RUN apk add --no-cache curl
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8080/health || exit 1
 


### PR DESCRIPTION
## Summary
- install curl before Dockerfile health check

## Testing
- `docker build -f Dockerfile.example .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68931449452c832a92e85d2fa9d4a597