### PR TITLE
feat: add kms encryption for s3 buckets

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -134,6 +134,12 @@ module "rds" {
   deletion_protection    = false
 }
 
+module "kms" {
+  source = "../../modules/kms"
+
+  environment = "dev"
+}
+
 module "s3" {
   source = "../../modules/s3"
 
@@ -141,6 +147,7 @@ module "s3" {
   app_name          = var.project_name
   enable_versioning = true
   log_retention_days = 30
+  kms_key_arn        = module.kms.kms_key_arn
 }
 
 module "waf" {
@@ -174,4 +181,5 @@ module "codepipeline" {
   source_object_key    = var.source_object_key
   codebuild_compute_type = "BUILD_GENERAL1_SMALL"
   log_retention_in_days = 30
+  kms_key_arn           = module.kms.kms_key_arn
 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -136,6 +136,12 @@ module "rds" {
   monitoring_interval    = 60
 }
 
+module "kms" {
+  source = "../../modules/kms"
+
+  environment = "prod"
+}
+
 module "s3" {
   source = "../../modules/s3"
 
@@ -143,6 +149,7 @@ module "s3" {
   app_name          = var.project_name
   enable_versioning = true
   log_retention_days = 365
+  kms_key_arn        = module.kms.kms_key_arn
 }
 
 module "waf" {
@@ -177,4 +184,5 @@ module "codepipeline" {
   source_object_key    = var.source_object_key
   codebuild_compute_type = "BUILD_GENERAL1_MEDIUM"
   log_retention_in_days = 90
+  kms_key_arn           = module.kms.kms_key_arn
 }

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -136,6 +136,12 @@ module "rds" {
   monitoring_interval    = 60
 }
 
+module "kms" {
+  source = "../../modules/kms"
+
+  environment = "stg"
+}
+
 module "s3" {
   source = "../../modules/s3"
 
@@ -143,6 +149,7 @@ module "s3" {
   app_name          = var.project_name
   enable_versioning = true
   log_retention_days = 90
+  kms_key_arn        = module.kms.kms_key_arn
 }
 
 module "waf" {
@@ -177,4 +184,5 @@ module "codepipeline" {
   source_object_key    = var.source_object_key
   codebuild_compute_type = "BUILD_GENERAL1_SMALL"
   log_retention_in_days = 60
+  kms_key_arn           = module.kms.kms_key_arn
 }

--- a/terraform/modules/codepipeline/main.tf
+++ b/terraform/modules/codepipeline/main.tf
@@ -42,7 +42,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "codepipeline_arti
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
@@ -52,7 +53,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_logs" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }

--- a/terraform/modules/codepipeline/variables.tf
+++ b/terraform/modules/codepipeline/variables.tf
@@ -67,3 +67,7 @@ variable "log_retention_in_days" {
   type        = number
   default     = 30
 }
+variable "kms_key_arn" {
+  description = "ARN of the KMS key for bucket encryption"
+  type        = string
+}

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -1,0 +1,15 @@
+resource "aws_kms_key" "this" {
+  description             = var.description
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+
+  tags = {
+    Name        = "${var.environment}-kms-key"
+    Environment = var.environment
+  }
+}
+
+resource "aws_kms_alias" "this" {
+  name          = "alias/${var.environment}-kms-key"
+  target_key_id = aws_kms_key.this.id
+}

--- a/terraform/modules/kms/outputs.tf
+++ b/terraform/modules/kms/outputs.tf
@@ -1,0 +1,4 @@
+output "kms_key_arn" {
+  description = "ARN of the KMS key"
+  value       = aws_kms_key.this.arn
+}

--- a/terraform/modules/kms/variables.tf
+++ b/terraform/modules/kms/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the KMS key"
+  type        = string
+  default     = "CMK for S3 encryption"
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -58,7 +58,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "app_assets" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
@@ -68,7 +69,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "app_logs" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
@@ -78,7 +80,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_logs" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -19,3 +19,7 @@ variable "log_retention_days" {
   type        = number
   default     = 90
 }
+variable "kms_key_arn" {
+  description = "ARN of the KMS key for bucket encryption"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- create reusable KMS module
- enable KMS server-side encryption for S3 buckets in s3 and codepipeline modules
- wire environments to provide KMS key ARN to modules

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -I https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689315a9adbc832abeeada15189d3ed6