### PR TITLE
Add ECS service autoscaling

### DIFF
--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -75,3 +75,63 @@ variable "secrets" {
   }))
   default = []
 }
+
+variable "enable_autoscaling" {
+  description = "Enable ECS service autoscaling"
+  type        = bool
+  default     = false
+}
+
+variable "autoscaling_min_capacity" {
+  description = "Minimum number of running tasks"
+  type        = number
+  default     = 1
+}
+
+variable "autoscaling_max_capacity" {
+  description = "Maximum number of running tasks"
+  type        = number
+  default     = 4
+}
+
+variable "autoscaling_metric_type" {
+  description = "Metric to use for autoscaling (CPU or MEMORY)"
+  type        = string
+  default     = "CPU"
+}
+
+variable "scale_out_threshold" {
+  description = "Metric threshold to trigger scale out"
+  type        = number
+  default     = 75
+}
+
+variable "scale_in_threshold" {
+  description = "Metric threshold to trigger scale in"
+  type        = number
+  default     = 25
+}
+
+variable "scale_out_cooldown" {
+  description = "Cooldown period after scaling out (seconds)"
+  type        = number
+  default     = 60
+}
+
+variable "scale_in_cooldown" {
+  description = "Cooldown period after scaling in (seconds)"
+  type        = number
+  default     = 300
+}
+
+variable "scale_out_adjustment" {
+  description = "Number of tasks to add on scale out"
+  type        = number
+  default     = 1
+}
+
+variable "scale_in_adjustment" {
+  description = "Number of tasks to remove on scale in"
+  type        = number
+  default     = -1
+}


### PR DESCRIPTION
## Summary
- support ECS service autoscaling using step scaling policies and CloudWatch alarms
- expose autoscaling configuration variables for min/max capacity, metric type and thresholds

## Testing
- `terraform fmt terraform/modules/ecs/main.tf` *(fails: command not found)*
- `terraform validate terraform/modules/ecs` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689315ac2f9c832a800faf0983f52488